### PR TITLE
migrate from atty to is-terminal due to RUSTSEC-2021-0145

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["command-line-interface", "encoding", "visualization"]
 license = "EPL-2.0"
 
 [dependencies]
-atty = "0.2.6"
+is-terminal = "0.4.4"
 serde = "1"
 serde_json = "1"
 yansi = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@
 //!    # }
 //!```
 
-use atty::Stream;
+use is_terminal::IsTerminal;
 use serde::Serialize;
 use serde_json::ser::Formatter;
 pub use serde_json::ser::{CompactFormatter, PrettyFormatter};
@@ -743,8 +743,8 @@ pub enum Output {
 impl ColorMode {
     fn is_tty(output: Output) -> bool {
         match output {
-            Output::StdOut => atty::is(Stream::Stdout),
-            Output::StdErr => atty::is(Stream::Stderr),
+            Output::StdOut => std::io::stdout().is_terminal(),
+            Output::StdErr => std::io::stderr().is_terminal(),
         }
     }
 


### PR DESCRIPTION
`atty` is unmaintained and has an outstanding vulnerability: https://rustsec.org/advisories/RUSTSEC-2021-0145