### PR TITLE
feat: use `std`'s `is_terminal()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "4.0.0"
 edition = "2021"
 authors = ["Jens Reimann <jreimann@redhat.com>", "Harald Hoyer <harald@redhat.com>"]
 description = "Colorize JSON, for printing it out on the command line"
+rust-version = "1.70.0"
 
 homepage = "https://github.com/ctron/colored_json"
 repository = "https://github.com/ctron/colored_json"
@@ -16,7 +17,6 @@ categories = ["command-line-interface", "encoding", "visualization"]
 license = "EPL-2.0"
 
 [dependencies]
-is-terminal = "0.4.4"
 serde = "1"
 serde_json = "1"
 yansi = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,12 +125,11 @@
 //!    # }
 //!```
 
-use is_terminal::IsTerminal;
 use serde::Serialize;
 use serde_json::ser::Formatter;
 pub use serde_json::ser::{CompactFormatter, PrettyFormatter};
 use serde_json::value::Value;
-use std::io;
+use std::io::{self, IsTerminal};
 
 pub use yansi::{Color, Style};
 
@@ -763,8 +762,8 @@ pub enum Output {
 impl ColorMode {
     fn is_tty(output: Output) -> bool {
         match output {
-            Output::StdOut => std::io::stdout().is_terminal(),
-            Output::StdErr => std::io::stderr().is_terminal(),
+            Output::StdOut => io::stdout().is_terminal(),
+            Output::StdErr => io::stderr().is_terminal(),
         }
     }
 


### PR DESCRIPTION
# Description

This replaces the usage of `is-terminal` crate with the `std` implementation.

This also explicitly sets the MSRV to the one in which this feature was stabilized.
